### PR TITLE
End to end Shasta assembly pipeline implemented

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,13 @@ helen_call_consensus:
 
 helen_stitch:
     # finally create the polished assembly
-    docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
-    	kishwars/helen:0.0.1.cpu \
-    	stitch.py \
-    	-i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
-    	-o . \
-    	-p $(ID)_shasta_mp_helen_assembly \
-    	-t $(CPU)
+        docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
+    	    kishwars/helen:0.0.1.cpu \
+    	    stitch.py \
+    	    -i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
+    	    -o . \
+    	    -p $(ID)_shasta_mp_helen_assembly \
+    	    -t $(CPU)
 
 freebayes:
 	echo "Downloading references..."

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,21 @@
 ID ?= GM24385.chr20
-CPU ?= 32
+CPU ?= 64
 BASE ?= $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 primary:
+    # this downloads the sample and converts a FASTQ file to FASTA file.
+    # I think there should be a check to see if the file is FASTA or FASTQ then convert if needed.
 	echo "Downloading GM24385 test sample..."
 	wget -N https://lc2019.s3-us-west-2.amazonaws.com/sample_data/GM24385/GM24385.chr20.fq
 	md5sum -c $(BASE)GM24385.chr20.fq.md5
 	sed -n '1~4s/^@/>/p;2~4p' GM24385.chr20.fq > GM24385.chr20.fasta
 
-secondary: shasta minimap2 samtools marginpolish helen
+secondary: shasta minimap2 samtools marginpolish helen_call_consensus helen_stitch
 	
 tertiary: freebayes
 
 shasta:
+    # generate Shasta assembly
 	rm -rf ShastaRun
 	docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
 		tpesout/shasta@sha256:048f180184cfce647a491f26822f633be5de4d033f894ce7bc01e8225e846236 \
@@ -20,11 +23,13 @@ shasta:
 	mv ShastaRun/Assembly.fasta shasta.fasta
 
 minimap2:
+    # Map the reads back to the Shasta assembly
 	docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
 		tpesout/minimap2@sha256:5df3218ae2afebfc06189daf7433f1ade15d7cf77d23e7351f210a098eb57858 \
-		-ax map-ont -t $(CPU) shasta.fasta $(ID).fasta
+		-ax map-ont -t $(CPU) shasta.fasta $(ID).fq
 
 samtools:
+    # convert the mapping to to BAM
 	docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
 		tpesout/samtools_sort:latest \
 		/data/minimap2.sam -@ $(CPU)
@@ -36,6 +41,7 @@ samtools:
 		index -@ $(CPU) /data/samtools_sort.bam
 
 marginpolish:
+    # generate marginPolish outputs
 	rm -rf marginPolish/
 	mkdir -p marginPolish
 	docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
@@ -44,11 +50,23 @@ marginpolish:
 		/opt/MarginPolish/params/allParams.np.human.guppy-ff-235.json -t $(CPU) -o /data/marginPolish/output -f
 	mv marginPolish/output.fa marginPolish.fa
 
-helen:
-	wget -N https://storage.googleapis.com/kishwar-helen/helen_trained_models/v0.0.1/r941_flip235_v001.pkl 
+helen_call_consensus:
+    # download the HELEN model and run call_consensus
+	wget -N https://storage.googleapis.com/kishwar-helen/helen_trained_models/v0.0.1/r941_flip235_v001.pkl
+
+	# delete previous run data (if there is any)
+	rm -rf $(ID)_helen_hdf5/
+
 	docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
 		kishwars/helen:0.0.1.cpu \
-		call_consensus.py -i /data/marginPolish -m r941_flip235_v001.pkl -o helen -w $(CPU)
+		call_consensus.py -i /data/marginPolish/ -m r941_flip235_v001.pkl -o $(ID)_helen_hdf5/ -w 0 -t $(CPU)
+
+helen_stitch:
+    # finally create the polished assembly
+    docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
+    		kishwars/helen:0.0.1.cpu \
+    		stitch.py -i $(ID)_helen_hdf5/*.hdf5 -o . -p $(ID)_shasta_mp_helen_assembly -t $(CPU)
+
 
 freebayes:
 	echo "Downloading references..."

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ helen:
 		kishwars/helen:0.0.1.cpu \
 		stitch.py \
 		-i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
-		-o helen_output/ \
+		-o /data/ \
 		-p $(ID)_shasta_mp_helen_assembly \
 		-t $(CPU)
 

--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,13 @@ helen:
 		-p $(ID)_prediction \
 		-w 0 \
 		-t $(CPU)
-
-    # finally create the polished assembly using stitch
-        docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
-    	        kishwars/helen:0.0.1.cpu \
-    	        stitch.py \
-    	        -i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
-    	        -o . \
-    	        -p $(ID)_shasta_mp_helen_assembly \
-    	        -t $(CPU)
+	docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
+		kishwars/helen:0.0.1.cpu \
+    	stitch.py \
+    	-i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
+    	-o helen_output/ \
+    	-p $(ID)_shasta_mp_helen_assembly \
+    	-t $(CPU)
 
 freebayes:
 	echo "Downloading references..."

--- a/Makefile
+++ b/Makefile
@@ -57,14 +57,23 @@ helen_call_consensus:
 	rm -rf $(ID)_helen_hdf5/
 	docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
 		kishwars/helen:0.0.1.cpu \
-		call_consensus.py -i /data/marginPolish/ -m r941_flip235_v001.pkl -o $(ID)_helen_hdf5/ -w 0 -t $(CPU)
+		call_consensus.py \
+		-i /data/marginPolish/ \
+		-m r941_flip235_v001.pkl \
+		-o $(ID)_helen_hdf5/ \
+		-p $(ID)_prediction \
+		-w 0 \
+		-t $(CPU)
 
 helen_stitch:
     # finally create the polished assembly
     docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
     		kishwars/helen:0.0.1.cpu \
-    		stitch.py -i $(ID)_helen_hdf5/$(wildcard *.hdf5) -o . -p $(ID)_shasta_mp_helen_assembly -t $(CPU)
-
+    		stitch.py \
+    		-i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
+    		-o . \
+    		-p $(ID)_shasta_mp_helen_assembly \
+    		-t $(CPU)
 
 freebayes:
 	echo "Downloading references..."

--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,12 @@ helen_call_consensus:
 helen_stitch:
     # finally create the polished assembly
     docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
-    		kishwars/helen:0.0.1.cpu \
-    		stitch.py \
-    		-i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
-    		-o . \
-    		-p $(ID)_shasta_mp_helen_assembly \
-    		-t $(CPU)
+    	kishwars/helen:0.0.1.cpu \
+    	stitch.py \
+    	-i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
+    	-o . \
+    	-p $(ID)_shasta_mp_helen_assembly \
+    	-t $(CPU)
 
 freebayes:
 	echo "Downloading references..."

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ primary:
 	md5sum -c $(BASE)GM24385.chr20.fq.md5
 	sed -n '1~4s/^@/>/p;2~4p' GM24385.chr20.fq > GM24385.chr20.fasta
 
-secondary: shasta minimap2 samtools marginpolish helen_call_consensus helen_stitch
+secondary: shasta minimap2 samtools marginpolish helen
 	
 tertiary: freebayes
 
@@ -50,7 +50,7 @@ marginpolish:
 		/opt/MarginPolish/params/allParams.np.human.guppy-ff-235.json -t $(CPU) -o /data/marginPolish/output -f
 	mv marginPolish/output.fa marginPolish.fa
 
-helen_call_consensus:
+helen:
     # download the HELEN model and run call_consensus
 	wget -N https://storage.googleapis.com/kishwar-helen/helen_trained_models/v0.0.1/r941_flip235_v001.pkl
 	# delete previous run data (if there is any)
@@ -65,8 +65,7 @@ helen_call_consensus:
 		-w 0 \
 		-t $(CPU)
 
-helen_stitch:
-    # finally create the polished assembly
+    # finally create the polished assembly using stitch
         docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
     	        kishwars/helen:0.0.1.cpu \
     	        stitch.py \

--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,12 @@ helen_call_consensus:
 helen_stitch:
     # finally create the polished assembly
         docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
-    	    kishwars/helen:0.0.1.cpu \
-    	    stitch.py \
-    	    -i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
-    	    -o . \
-    	    -p $(ID)_shasta_mp_helen_assembly \
-    	    -t $(CPU)
+    	        kishwars/helen:0.0.1.cpu \
+    	        stitch.py \
+    	        -i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
+    	        -o . \
+    	        -p $(ID)_shasta_mp_helen_assembly \
+    	        -t $(CPU)
 
 freebayes:
 	echo "Downloading references..."

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 ID ?= GM24385.chr20
 CPU ?= 64
+# reserve some CPUs while running call_consensus
+HELEN_CALL_CONSENSUS_CPU ?= 56
 BASE ?= $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 primary:
@@ -63,14 +65,14 @@ helen:
 		-o $(ID)_helen_hdf5/ \
 		-p $(ID)_prediction \
 		-w 0 \
-		-t $(CPU)
+		-t $(HELEN_CALL_CONSENSUS_CPU)
 	docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
 		kishwars/helen:0.0.1.cpu \
-    	stitch.py \
-    	-i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
-    	-o helen_output/ \
-    	-p $(ID)_shasta_mp_helen_assembly \
-    	-t $(CPU)
+		stitch.py \
+		-i $(ID)_helen_hdf5/$(ID)_prediction.hdf \
+		-o helen_output/ \
+		-p $(ID)_shasta_mp_helen_assembly \
+		-t $(CPU)
 
 freebayes:
 	echo "Downloading references..."

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,8 @@ marginpolish:
 helen_call_consensus:
     # download the HELEN model and run call_consensus
 	wget -N https://storage.googleapis.com/kishwar-helen/helen_trained_models/v0.0.1/r941_flip235_v001.pkl
-
 	# delete previous run data (if there is any)
 	rm -rf $(ID)_helen_hdf5/
-
 	docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
 		kishwars/helen:0.0.1.cpu \
 		call_consensus.py -i /data/marginPolish/ -m r941_flip235_v001.pkl -o $(ID)_helen_hdf5/ -w 0 -t $(CPU)
@@ -65,7 +63,7 @@ helen_stitch:
     # finally create the polished assembly
     docker run -it --rm --user=`id -u`:`id -g` --cpus="$(CPU)" -v `pwd`:/data \
     		kishwars/helen:0.0.1.cpu \
-    		stitch.py -i $(ID)_helen_hdf5/*.hdf5 -o . -p $(ID)_shasta_mp_helen_assembly -t $(CPU)
+    		stitch.py -i $(ID)_helen_hdf5/$(wildcard *.hdf5) -o . -p $(ID)_shasta_mp_helen_assembly -t $(CPU)
 
 
 freebayes:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 Tooling to run the primary, secondary and tertiary pipelines for the UCSC Undiagnosed Pediatric Disease Center
 
+## Install dependencies
+To run this program, please install `Make`:
+```bash
+sudo apt-get update
+sudo apt-get install make
+```
+
+and `Docker`:
+```bash
+sudo apt install docker.io
+sudo systemctl start docker
+sudo systemctl enable docker
+```
+
+To run `Docker` without root privilege:
+```bash
+sudo groupadd docker
+sudo gpasswd -a $USER docker
+# now log out and log in once or run:
+newgrp docker
+```
+
 ## Quick Start
 
 Clone this repo, create a directory for data and run a test sample:
@@ -10,5 +32,7 @@ Clone this repo, create a directory for data and run a test sample:
 git clone https://github.com/ucsc-upd/pipelines.git
 mkdir data
 cd data
-make -f ../Makefile download secondary
+make -f ../Makefile primary secondary
 ```
+
+This will generate a polished genome assembly of the input inside `/data/helen_output/` 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,17 @@ sudo gpasswd -a $USER docker
 newgrp docker
 ```
 
+TIPS:
+To clean all docker images to re-download  them all:
+```bash
+docker rmi $(docker images -a -q)
+```
+
 ## Quick Start
 
 Clone this repo, create a directory for data and run a test sample:
 
-```
+```bash
 git clone https://github.com/ucsc-upd/pipelines.git
 mkdir data
 cd data

--- a/README.md
+++ b/README.md
@@ -41,4 +41,99 @@ cd data
 make -f ../Makefile primary secondary
 ```
 
-This will generate a polished genome assembly of the input inside `/data/helen_output/` 
+This will generate a polished genome assembly of the input inside `GM24385.chr20_shasta_mp_helen_assembly.fa`
+
+
+## Quality assessment
+```
+NOTE:  Shasta is non-deterministic because of dynamic load balancing.   
+Because of that, repeating the same run twice under identical conditions 
+does not necessarily give bit-identical results.
+```
+
+If you ran this pipeline for `GM24385.chr20` then you can assess the quality of the polished and unpolished  assembly using `pomoxis`.
+
+Install Pomoxis:
+```bash
+sudo apt-get install virtualenv gcc  g++ zlib1g-dev libncurses5-dev \
+python3-all-dev libhdf5-dev libatlas-base-dev libopenblas-base \
+libopenblas-dev libbz2-dev liblzma-dev libffi-dev make \
+python-virtualenv cmake wget bzip2
+
+git clone --recursive https://github.com/nanoporetech/pomoxis
+cd pomoxis
+make install
+. ./venv/bin/activate
+```
+
+Download truth assembly:
+```bash
+wget https://storage.googleapis.com/kishwar-helen/truth_assemblies/HG002/HG002_GRCh38_h1_chr20.fa
+wget https://storage.googleapis.com/kishwar-helen/truth_assemblies/HG002/HG002_h1_chr20.bed
+```
+
+Assess the Shasta assembly:
+```bash
+mkdir shasta_assessment
+
+assess_assembly \
+-i shasta.fasta \
+-r HG002_GRCh38_h1_chr20.fa \
+-p shasta_assessment/hg002_chr20_shasta \
+-b HG002_h1_chr20.bed \
+-t <number_of_threads> \
+-T
+```
+
+Expected output:
+```bash
+#  Percentage Errors
+  name     mean     q10      q50      q90
+ err_ont  1.181%   0.798%   1.092%   1.640%
+ err_bal  1.083%   0.717%   1.008%   1.474%
+    iden  0.062%   0.021%   0.056%   0.119%
+     del  0.914%   0.614%   0.852%   1.212%
+     ins  0.107%   0.031%   0.069%   0.188%
+
+#  Q Scores
+  name     mean      q10      q50      q90
+ err_ont  19.28    20.98    19.62    17.85
+ err_bal  19.65    21.44    19.97    18.31
+    iden  32.04    36.74    32.49    29.26
+     del  20.39    22.12    20.70    19.16
+     ins  29.69    35.09    31.61    27.25
+```
+
+Then assess the polished assembly:
+```bash
+mkdir shasta_helen_assessment
+
+assess_assembly \
+-i GM24385.chr20_shasta_mp_helen_assembly.fa \
+-r HG002_GRCh38_h1_chr20.fa \
+-p shasta_helen_assessment/hg002_chr20_helen \
+-b HG002_h1_chr20.bed \
+-t <number_of_threads> \
+-T
+```
+
+Expected output:
+```bash
+#  Percentage Errors
+  name     mean     q10      q50      q90
+ err_ont  0.526%   0.208%   0.358%   0.738%
+ err_bal  0.482%   0.185%   0.333%   0.641%
+    iden  0.093%   0.001%   0.033%   0.084%
+     del  0.264%   0.115%   0.205%   0.384%
+     ins  0.125%   0.012%   0.078%   0.210%
+
+#  Q Scores
+  name     mean      q10      q50      q90
+ err_ont  22.79    26.82    24.46    21.32
+ err_bal  23.17    27.33    24.78    21.93
+    iden  30.32    50.00    34.80    30.75
+     del  25.78    29.39    26.87    24.15
+     ins  29.02    39.34    31.07    26.78
+```
+
+The assessment confirms error rate reduction of Shasta assembly from `1.181%` to `0.526%`.


### PR DESCRIPTION
This pull request has updated readme with a Makefile that can generate a polished assembly of chr20.

Notes:
- The number of CPUs has been increased to 64. Reduce as needed.
- Make sure you remove all existing images in your system, command given in Readme. 
-  Assessment command also included but not necessary for this demonstration.
- This pipeline takes about 2 hours to finish.