### PR TITLE
Structural variant annotation and report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,13 @@ references/clairvoyante:
 			--ctgStart 1000000 \
 			--ctgEnd 1010000
 
+##
+## Reports
+##
+
+sv-report.pdf: na12878-chr11.sniffles.ann.vcf
+	Rscript -e 'rma	rkdown::render("sv-report.Rmd")' na12878-chr11.sniffles.ann.vcf
+
 benchmark:
 	# BROKEN - not ready to use yet
 	# Compare the region we tried to call variants on to the ground truth from GIAB

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz:
 	echo "Downloading LoF intolerance score from gnomAD..."
 	wget -N -P references https://storage.googleapis.com/gnomad-public/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz
 
+references/simpleRepeat.txt.gz:
+	echo "Downloading repeat annotation..."
+	wget -N -P references https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/simpleRepeat.txt.gz
+
 #
 # Download NA12878 chr11 from https://github.com/nanopore-wgs-consortium
 # and convert to fq as a test sample
@@ -127,11 +131,19 @@ samples/na12878-chr11/na12878-chr11.fq.gz:
 ## Reports
 ##
 
-%.sv-report.pdf: %.sniffles.ann.freqGnomADcov10.vcf %.svim.ann.freqGnomADcov10.vcf /references/gene_position_info.txt references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz
+%.sv-report.pdf: %.sniffles.ann.freqGnomADcov10.vcf %.svim.ann.freqGnomADcov10.vcf /references/gene_position_info.txt references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
 	echo "Producing SV report..."
 	$(DOCKER_RUN) \
 		-v `realpath .`:/app -w /app \
 		jmonlong/sveval-rmarkdown@sha256:0782c113c67fd583f6317c0868231c45bb7d02b0e24bea3e511cbdb2ee428a6e \
-		Rscript -e 'rmarkdown::render("sv-report.Rmd")' /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz
+		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="pdf_document")' /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
 	mv sv-report.pdf $@
+
+%.sv-report.html: %.sniffles.ann.freqGnomADcov10.vcf %.svim.ann.freqGnomADcov10.vcf /references/gene_position_info.txt references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
+	echo "Producing SV report..."
+	$(DOCKER_RUN) \
+		-v `realpath .`:/app -w /app \
+		jmonlong/sveval-rmarkdown@sha256:0782c113c67fd583f6317c0868231c45bb7d02b0e24bea3e511cbdb2ee428a6e \
+		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="html_document")' /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
+	mv sv-report.html $@
 

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ samples/na12878-chr11/na12878-chr11.fq.gz:
 	$(DOCKER_RUN) \
 		-v `realpath .`:/app -w /app \
 		jmonlong/sveval-rmarkdown@sha256:0782c113c67fd583f6317c0868231c45bb7d02b0e24bea3e511cbdb2ee428a6e \
-		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="pdf_document")' /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz /references/simpleRepeat.txt.gz
+		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="pdf_document")' /data/$$(echo $^ | cut -f1 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz /references/simpleRepeat.txt.gz
 	mv sv-report.pdf $@
 
 %.sv-report.html: %.sniffles.ann.freqGnomADcov10.vcf %.svim.ann.freqGnomADcov10.vcf references/gene_position_info.txt references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
@@ -151,6 +151,6 @@ samples/na12878-chr11/na12878-chr11.fq.gz:
 	$(DOCKER_RUN) \
 		-v `realpath .`:/app -w /app \
 		jmonlong/sveval-rmarkdown@sha256:0782c113c67fd583f6317c0868231c45bb7d02b0e24bea3e511cbdb2ee428a6e \
-		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="html_document")' /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz /references/simpleRepeat.txt.gz
+		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="html_document")' /data/$$(echo $^ | cut -f1 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz /references/simpleRepeat.txt.gz
 	mv sv-report.html $@
 

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ samples/na12878-chr11/na12878-chr11.fq.gz:
 %.sniffles.freqGnomADcov10.vcf: %.sniffles.vcf references/gnomad_v2_sv.sites.pass.lifted.vcf.gz
 	echo "Annotating SV frequency using the gnomAD-SV catalog..."
 	$(DOCKER_RUN) \
-		jmonlong/sveval@sha256:e34bde2282316637bb197bf8d4305f9085659bd043d85ead32159e4a1404323f \
+		jmonlong/sveval@sha256:719143592e86279d0748797044906305a42c6ac9af01fcad70fe6fa1a1aa5a04 \
 		R -e "sveval::freqAnnotate('$(PREREQ)', '/references/gnomad_v2_sv.sites.pass.lifted.vcf.gz', out.vcf='$(TARGET)', cov=.1)"
 
 %.svim.vcf: %.sorted.bam %.sorted.bam.bai references/hg38.fa

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ samples/na12878-chr11/na12878-chr11.fq.gz:
 	echo "Producing SV report..."
 	$(DOCKER_RUN) \
 		-v `realpath .`:/app -w /app \
-		jmonlong/sveval-rmarkdown@sha256:0782c113c67fd583f6317c0868231c45bb7d02b0e24bea3e511cbdb2ee428a6e \
+		jmonlong/sveval-rmarkdown@sha256:d2f504ee111aeaeecdb061d0adf86aca766a8ab116c541ce208b79bc9c448cbc \
 		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="pdf_document")' /data/$$(echo $^ | cut -f1 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz /references/simpleRepeat.txt.gz
 	mv sv-report.pdf $@
 
@@ -150,7 +150,7 @@ samples/na12878-chr11/na12878-chr11.fq.gz:
 	echo "Producing SV report..."
 	$(DOCKER_RUN) \
 		-v `realpath .`:/app -w /app \
-		jmonlong/sveval-rmarkdown@sha256:0782c113c67fd583f6317c0868231c45bb7d02b0e24bea3e511cbdb2ee428a6e \
+		jmonlong/sveval-rmarkdown@sha256:d2f504ee111aeaeecdb061d0adf86aca766a8ab116c541ce208b79bc9c448cbc \
 		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="html_document")' /data/$$(echo $^ | cut -f1 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz /references/simpleRepeat.txt.gz
 	mv sv-report.html $@
 

--- a/Makefile
+++ b/Makefile
@@ -106,18 +106,18 @@ samples/na12878-chr11/na12878-chr11.fq.gz:
 		quay.io/biocontainers/sniffles@sha256:98a5b91db2762ed3b8aca3bffd3dca7d6b358d2a4a4a6ce7579213d9585ba08a \
 		sniffles -m /data/$(PREREQ) -v /data/$(TARGET) --genotype
 
-%.sniffles.freqGnomADcov10.vcf: %.sniffles.vcf references/gnomad_v2_sv.sites.pass.lifted.vcf.gz
-	echo "Annotating SV frequency using the gnomAD-SV catalog..."
-	$(DOCKER_RUN) \
-		jmonlong/sveval@sha256:719143592e86279d0748797044906305a42c6ac9af01fcad70fe6fa1a1aa5a04 \
-		R -e "sveval::freqAnnotate('$(PREREQ)', '/references/gnomad_v2_sv.sites.pass.lifted.vcf.gz', out.vcf='$(TARGET)', cov=.1)"
-
 %.svim.vcf: %.sorted.bam %.sorted.bam.bai references/hg38.fa
 	echo "Calling variants with svim..."
 	$(DOCKER_RUN) \
 		quay.io/biocontainers/svim@sha256:4239718261caf12f6c27d36d5657c13a2ca3b042c833058d345b04531b576442 \
 		svim alignment /data/svim /data/$(PREREQ) /references/hg38.fa --sample $(TARGET)
 	mv $(@D)/svim/final_results.vcf $(@)
+
+%.freqGnomADcov10.vcf: %.vcf references/gnomad_v2_sv.sites.pass.lifted.vcf.gz
+	echo "Annotating SV frequency using the gnomAD-SV catalog..."
+	$(DOCKER_RUN) \
+		jmonlong/sveval@sha256:719143592e86279d0748797044906305a42c6ac9af01fcad70fe6fa1a1aa5a04 \
+		R -e "sveval::freqAnnotate('/data/$(PREREQ)', '/references/gnomad_v2_sv.sites.pass.lifted.vcf.gz', out.vcf='/data/$(TARGET)', min.cov=.1)"
 
 references/clairvoyante:
 	echo "Downloading clairvoyante trained model..."

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,11 @@ references/hg38.fa.fai: references/hg38.fa
 		quay.io/ucsc_cgl/samtools@sha256:2abed6c570ef4614fbd43673ddcdc1bbcd7318cb067ffa3d42eb50fc6ec1b95f \
 		faidx /references/hg38.fa
 
+references/gene_position_info.txt:
+	echo "Downloading gene list..."
+	mkdir -p references
+	wget -N -P references https://github.com/ucsc-upd/operations/files/3628601/gene_position_info.txt
+
 references/gnomad_v2_sv.sites.pass.lifted.vcf.gz:
 	echo "Downloading SV catalog from gnomAD-SV..."
 	mkdir -p references
@@ -54,10 +59,12 @@ references/gnomad_v2_sv.sites.pass.lifted.vcf.gz:
 
 references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz:
 	echo "Downloading LoF intolerance score from gnomAD..."
+	mkdir -p references
 	wget -N -P references https://storage.googleapis.com/gnomad-public/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz
 
 references/simpleRepeat.txt.gz:
 	echo "Downloading repeat annotation..."
+	mkdir -p references
 	wget -N -P references https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/simpleRepeat.txt.gz
 
 #

--- a/Makefile
+++ b/Makefile
@@ -138,19 +138,19 @@ samples/na12878-chr11/na12878-chr11.fq.gz:
 ## Reports
 ##
 
-%.sv-report.pdf: %.sniffles.ann.freqGnomADcov10.vcf %.svim.ann.freqGnomADcov10.vcf /references/gene_position_info.txt references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
+%.sv-report.pdf: %.sniffles.ann.freqGnomADcov10.vcf %.svim.ann.freqGnomADcov10.vcf references/gene_position_info.txt references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
 	echo "Producing SV report..."
 	$(DOCKER_RUN) \
 		-v `realpath .`:/app -w /app \
 		jmonlong/sveval-rmarkdown@sha256:0782c113c67fd583f6317c0868231c45bb7d02b0e24bea3e511cbdb2ee428a6e \
-		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="pdf_document")' /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
+		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="pdf_document")' /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz /references/simpleRepeat.txt.gz
 	mv sv-report.pdf $@
 
-%.sv-report.html: %.sniffles.ann.freqGnomADcov10.vcf %.svim.ann.freqGnomADcov10.vcf /references/gene_position_info.txt references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
+%.sv-report.html: %.sniffles.ann.freqGnomADcov10.vcf %.svim.ann.freqGnomADcov10.vcf references/gene_position_info.txt references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
 	echo "Producing SV report..."
 	$(DOCKER_RUN) \
 		-v `realpath .`:/app -w /app \
 		jmonlong/sveval-rmarkdown@sha256:0782c113c67fd583f6317c0868231c45bb7d02b0e24bea3e511cbdb2ee428a6e \
-		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="html_document")' /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz references/simpleRepeat.txt.gz
+		Rscript -e 'rmarkdown::render("sv-report.Rmd", output_format="html_document")' /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /data/$$(echo $^ | cut -f2 -d' ' | xargs basename) /references/gene_position_info.txt /references/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz /references/simpleRepeat.txt.gz
 	mv sv-report.html $@
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ This will take approximately 72 minutes using 32 cores and genereate the followi
 4.8G Sep  8 11:24 na12878-chr11.sorted.bam
 ```
 
+## Structural variant report
+
+```bash
+make samples/na12878-chr11/na12878-chr11.sv-report.pdf
+## or 
+make samples/na12878-chr11/na12878-chr11.sv-report.html
+```
+
 ## Additional Samples
 To process additional samples place their fastq in samples/<id>/<id>.fq.gz and call make for any specific target. For example:
 ```

--- a/sv-report.Rmd
+++ b/sv-report.Rmd
@@ -1,0 +1,74 @@
+---
+title: Structural Variation Report
+author: UPD-UCSC
+output: pdf_document
+---
+
+```{r include=FALSE}
+knitr::opts_chunk$set(echo=FALSE, message=FALSE, warning=FALSE, fig.width=10)
+```
+
+```{r setup}
+## Read input arguments
+## 1: VCF file from Sniffles
+args = commandArgs(TRUE)
+
+## Load packages
+library(VariantAnnotation)
+library(dplyr)
+library(knitr)
+library(kableExtra)
+
+## Parse the SnpEff field EFF
+parseEff <- function(eff){
+  effect = gsub('(.*)\\(.*\\)', '\\1', eff)
+  target = gsub('.*\\((.*)\\)', '\\1', eff)
+  target = strsplit(target, '\\|')[[1]]
+  return(tibble(effect=effect, impact=target[[1]], gene=target[[6]],
+              target.type=target[[7]]))
+}
+
+## Read vcfs
+vcf = readVcf(args[1], genome='')
+```
+
+
+# High impact variants affecting protein-coding genes
+
+```{r highimpact, results='asis'}
+high.ii = which(unlist(lapply(info(vcf)$EFF, function(effs) any(grepl('HIGH', effs)))))
+eff.df = lapply(high.ii, function(ii){
+  effs = lapply(info(vcf)$EFF[[ii]], parseEff)
+  effs = do.call(rbind, effs)
+  effs$id = ii
+  effs
+})
+eff.df = do.call(rbind, eff.df)
+
+high.df = eff.df %>% filter(impact=='HIGH', target.type=='protein_coding')
+
+t = lapply(unique(high.df$id), function(ii){
+  vcf = vcf[ii]
+  res = tibble(
+    chr=as.character(seqnames(rowRanges(vcf))),
+    start=start(rowRanges(vcf)),
+    type=info(vcf)$SVTYPE,
+    size=info(vcf)$SVLEN,
+    quality=rowRanges(vcf)$QUAL,
+    reads=info(vcf)$RE)
+  df = high.df %>% filter(id==ii) %>% select(gene, effect) %>% unique
+  cat('\n\n## ', res$type, 'in', paste(unique(df$gene), collapse=' '), '\n\n')
+  res %>% kable(booktabs=TRUE) %>% cat
+  cat('\n\n### Effect(s) \n\n')
+  df %>% mutate(effect=gsub('\\+', ' \\+ ', effect)) %>%
+    kable(booktabs=TRUE) %>% column_spec(2, width='10cm') %>% cat
+})
+```
+
+# Next
+
+- Filter variants by frequency.
+- Filter genes by LoF intolerance score from gnomAD.
+- Filter genes from our in-house list.
+- Filter variants based on the call quality.
+- Merge both VCFs.

--- a/sv-report.Rmd
+++ b/sv-report.Rmd
@@ -5,7 +5,10 @@ header-includes:
 - \usepackage{booktabs}
 - \usepackage{makecell}
 urlcolor: teal
-output: pdf_document
+output:
+  pdf_document:
+    toc: true
+    toc_depth: 2
 ---
 
 ```{r include=FALSE}
@@ -17,8 +20,9 @@ knitr::opts_chunk$set(echo=FALSE, message=FALSE, warning=FALSE, fig.width=10)
 ## 1: VCF file from Sniffles
 ## 2: VCF file from SVIM
 ## 3: gene list file
+## 4: gene and LoF intolerance score file
 args = commandArgs(TRUE)
-args = c('na12878-chr11.sniffles.ann.freqGnomADcov10.vcf','na12878-chr11.svim.ann.freqGnomADcov10.vcf','gene_position_info.txt')
+args = c('na12878-chr11.sniffles.ann.freqGnomADcov10.vcf','na12878-chr11.svim.ann.freqGnomADcov10.vcf','gene_position_info.txt', 'gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz')
 
 ## Load packages
 library(sveval)
@@ -41,6 +45,9 @@ mdLinkGenes <- function(genes){
 }
 latexLinkGenes <- function(genes){
   paste0('{\\href{https://www.ncbi.nlm.nih.gov/gene?term=(', genes, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D}{', genes, '}}')
+}
+latexLinkPli <- function(scores, genes, digits=3){
+  paste0('{\\href{https://gnomad.broadinstitute.org/gene/', genes, '}{', round(scores, digits), '}}')
 }
 latexLinkPos <- function(chr, pos){
   paste0('{\\href{https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', chr, '%3A', pos-500, '-', pos+500, '}{', chr, ':', pos, '}}')
@@ -77,6 +84,10 @@ info(vcf.sv)$METHOD = 'SVIM'
 ## Read gene list
 genes = read.table(args[3], as.is=TRUE, header=TRUE)
 
+## Read pli score
+pli.df = read.table(args[4], as.is=TRUE, header=TRUE, sep='\t')
+pli.df = pli.df %>% select(gene, pLI)
+
 ## FOR TESTING PURPOSE
 genes$hgnc_symbol[1] = 'MUC5B'
 ```
@@ -101,15 +112,25 @@ eff.df = do.call(rbind, eff.df)
 The structural variants found by [Sniffles](https://github.com/fritzsedlazeck/Sniffles) and [SVIM](https://github.com/eldariont/svim) were annotated by [SnpEff](http://snpeff.sourceforge.net/) and with the frequency of variants in the [gnoma-SV catalog](https://macarthurlab.org/2019/03/20/structural-variants-in-gnomad/).
 
 The variants' "effects" in this report come from SnpEff and follow the format [described in SnpEff documentation](http://snpeff.sourceforge.net/SnpEff_manual.html#eff).
+In this report we select variants with a predicted *HIGH* effect.
 
-# High impact variants in genes of interest
+The *pLI* score was computed by the [gnomAD project](https://gnomad.broadinstitute.org/).
+It represents the probability that the gene is intolerant to loss-of-function variants.
+A variant affecting a gene with a high pLI score (e.g. >0.9) is more likely to have a biological impact.
+The variants in each section are ordered to show those affecting genes with the highest pLI first.
+
+# By variant
+
+## High impact variants in genes of interest
 
 Genes of interest: `r sort(genes$hgnc_symbol)`.
 
 Note: for testing purposes I added *MUC5B* to the list of genes.
 
 ```{r genesel, results='asis'}
-high.df = eff.df %>% filter(impact=='HIGH', gene %in% genes$hgnc_symbol) %>% arrange(gene)
+high.df = eff.df %>% filter(impact=='HIGH', gene %in% genes$hgnc_symbol) %>%
+  merge(pli.df, all.x=TRUE) %>% arrange(desc(pLI))
+  
 high.ii = high.df %>% select(id, method) %>% unique
 
 ## Write a section for each variant
@@ -133,23 +154,25 @@ t = lapply(1:nrow(high.ii), function(ii){
     method=info(vcf)$METHOD,
     nb.methods=info(vcf)$METHODS)
   ## Effect info
-  df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique
+  df = high.df %>% filter(id==id.ii) %>% select(gene, effect, pLI) %>% unique
   ## Write Markdown/Latex section
-  cat('\n\n## ', res$type, 'in', paste(mdLinkGenes(unique(df$gene)), collapse=' '), '\n\n')
+  cat('\n\n### ', res$type, 'in', paste(mdLinkGenes(unique(df$gene)), collapse=' '), '\n\n')
   res %>% kable(booktabs=TRUE, escape=FALSE) %>% cat
-  cat('\n\n### Effect(s) \n\n')
+  cat('\n\n#### Effect(s) \n\n')
   df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
                 effect=gsub('_', '\\\\_', effect),
+                pLI=latexLinkPli(pLI, gene),
                 gene=latexLinkGenes(gene)) %>%
     kable(booktabs=TRUE, escape=FALSE) %>% column_spec(2, width=col.width) %>% cat
 })
 ```
 
-# High impact variants affecting other protein-coding genes
+## High impact variants affecting other protein-coding genes
 
 ```{r proteincoding, results='asis'}
 high.df = eff.df %>% filter(impact=='HIGH', target.type=='protein_coding',
-                            !(gene %in% genes$hgnc_symbol)) %>% arrange(gene)
+                            !(gene %in% genes$hgnc_symbol)) %>%
+  merge(pli.df, all.x=TRUE) %>% arrange(desc(pLI))
 high.ii = high.df %>% select(id, method) %>% unique
 
 ## Write a section for each variant
@@ -173,19 +196,19 @@ t = lapply(1:nrow(high.ii), function(ii){
     method=info(vcf)$METHOD,
     nb.methods=info(vcf)$METHODS)
   ## Effect info
-  df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique
+  df = high.df %>% filter(id==id.ii) %>% select(gene, effect, pLI) %>% unique
   ## Write Markdown/Latex section
-  cat('\n\n## ', res$type, 'in', paste(mdLinkGenes(unique(df$gene)), collapse=' '), '\n\n')
+  cat('\n\n### ', res$type, 'in', paste(mdLinkGenes(unique(df$gene)), collapse=' '), '\n\n')
   res %>% kable(booktabs=TRUE, escape=FALSE) %>% cat
-  cat('\n\n### Effect(s) \n\n')
+  cat('\n\n#### Effect(s) \n\n')
   df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
                 effect=gsub('_', '\\\\_', effect),
+                pLI=latexLinkPli(pLI, gene),
                 gene=latexLinkGenes(gene)) %>%
     kable(booktabs=TRUE, escape=FALSE) %>% column_spec(2, width=col.width) %>% cat
 })
 ```
 
-# Next
+# By gene
 
-- Add LoF intolerance score from gnomAD.
-- Rank variants by priority (effect + frequency + pli score).
+*Soon...*

--- a/sv-report.Rmd
+++ b/sv-report.Rmd
@@ -52,8 +52,10 @@ latexLinkPli <- function(scores, genes, digits=3){
 mdLinkPli <- function(scores, genes, digits=3){
   paste0('[',round(scores, digits), '](https://gnomad.broadinstitute.org/gene/', genes,')')
 }
-latexLinkPos <- function(chr, pos){
-  paste0('{\\href{https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', chr, '%3A', pos-500, '-', pos+500, '}{', chr, ':', pos, '}}')
+latexLinkPos <- function(chr, pos, type, size, flanks=500){
+  size = ifelse(type %in% c('DEL','DUP','INV'), abs(size), 1)
+  paste0('{\\href{https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', chr, '%3A', pos-flanks, '-', pos+size+flanks,
+         '&highlight=hg38.', chr, '%3A', pos, '-', pos+size, '%23AA0000}{', chr, ':', pos, '}}')
 }
 col.width='13cm'
 col.width.gene='5cm'
@@ -151,7 +153,7 @@ t = lapply(1:nrow(high.ii), function(ii){
   }
   ## Variant info
   res = tibble(
-    pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
+    pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
     type=info(vcf)$SVTYPE,
     size=info(vcf)$SVLEN,
     ## quality=rowRanges(vcf)$QUAL,
@@ -193,7 +195,7 @@ t = lapply(1:nrow(high.ii), function(ii){
   }
   ## Variant info
   res = tibble(
-    pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
+    pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
     type=info(vcf)$SVTYPE,
     size=info(vcf)$SVLEN,
     ## quality=rowRanges(vcf)$QUAL,
@@ -234,7 +236,7 @@ t = lapply(unique(high.df$gene), function(gene.name){
     vcf = vcf.sn[id.ii]
     vars = tibble(
       id=id.ii,
-      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
+      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
       type=info(vcf)$SVTYPE,
       size=info(vcf)$SVLEN,
       ## quality=rowRanges(vcf)$QUAL,
@@ -248,7 +250,7 @@ t = lapply(unique(high.df$gene), function(gene.name){
     vcf = vcf.sv[id.ii]
     vars = tibble(
       id=id.ii,
-      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
+      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
       type=info(vcf)$SVTYPE,
       size=info(vcf)$SVLEN,
       ## quality=rowRanges(vcf)$QUAL,
@@ -286,7 +288,7 @@ t = lapply(unique(high.df$gene), function(gene.name){
     vcf = vcf.sn[id.ii]
     vars = tibble(
       id=id.ii,
-      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
+      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
       type=info(vcf)$SVTYPE,
       size=info(vcf)$SVLEN,
       ## quality=rowRanges(vcf)$QUAL,
@@ -300,7 +302,7 @@ t = lapply(unique(high.df$gene), function(gene.name){
     vcf = vcf.sv[id.ii]
     vars = tibble(
       id=id.ii,
-      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
+      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
       type=info(vcf)$SVTYPE,
       size=info(vcf)$SVLEN,
       ## quality=rowRanges(vcf)$QUAL,

--- a/sv-report.Rmd
+++ b/sv-report.Rmd
@@ -4,7 +4,6 @@ author: UPD-UCSC
 header-includes:
 - \usepackage{booktabs}
 - \usepackage{makecell}
-- \usepackage{makecell}
 urlcolor: teal
 output:
   pdf_document:
@@ -181,3 +180,4 @@ t = lapply(1:nrow(high.ii), function(ii){
 # Next
 
 - Add LoF intolerance score from gnomAD.
+- Rank variants by priority (effect + frequency + pli score).

--- a/sv-report.Rmd
+++ b/sv-report.Rmd
@@ -83,6 +83,10 @@ eff.df = lapply(list(vcf.sn, vcf.sv), function(vcf){
 eff.df = do.call(rbind, eff.df)
 ```
 
+The structural variants found by [Sniffles](https://github.com/fritzsedlazeck/Sniffles) and [SVIM](https://github.com/eldariont/svim) were annotated by [SnpEff](http://snpeff.sourceforge.net/) and with the frequency of variants in the [gnoma-SV catalog](https://macarthurlab.org/2019/03/20/structural-variants-in-gnomad/).
+
+The variants "effects" in this report come from SnpEff and follow the format [described in SnpEff documentation](http://snpeff.sourceforge.net/SnpEff_manual.html#eff).
+
 # High impact variants in genes of interest
 
 Genes of interest include: `r sort(genes$hgnc_symbol)`.
@@ -103,16 +107,16 @@ t = lapply(1:nrow(high.ii), function(ii){
     reads = info(vcf.sv)$SUPPORT[id.ii]
   }
   res = tibble(
-    chr=as.character(seqnames(rowRanges(vcf))),
-    start=start(rowRanges(vcf)),
     type=info(vcf)$SVTYPE,
+    pos=paste0('[', as.character(seqnames(rowRanges(vcf))), ':', start(rowRanges(vcf)), '](https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', as.character(seqnames(rowRanges(vcf))), '%3A', start(rowRanges(vcf))-500, '-', start(rowRanges(vcf))+500, ')')
     size=info(vcf)$SVLEN,
     ## quality=rowRanges(vcf)$QUAL,
     reads=reads,
     gnomad.freq=info(vcf)$AFMAX,
     method=info(vcf)$METHOD,
     nb.methods=info(vcf)$METHODS)
-  df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique
+  df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique %>%
+    mutate(gene=paste0('[', gene, '](https://www.ncbi.nlm.nih.gov/gene?term=(', gene, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D)'))
   ## PDF version
   cat('\n\n## ', res$type, 'in', paste(unique(df$gene), collapse=' '), '\n\n')
   res %>% kable(booktabs=TRUE) %>% cat
@@ -139,16 +143,16 @@ t = lapply(1:nrow(high.ii), function(ii){
     reads = info(vcf.sv)$SUPPORT[id.ii]
   }
   res = tibble(
-    chr=as.character(seqnames(rowRanges(vcf))),
-    start=start(rowRanges(vcf)),
     type=info(vcf)$SVTYPE,
+    pos=paste0('[', as.character(seqnames(rowRanges(vcf))), ':', start(rowRanges(vcf)), '](https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', as.character(seqnames(rowRanges(vcf))), '%3A', start(rowRanges(vcf))-500, '-', start(rowRanges(vcf))+500, ')')
     size=info(vcf)$SVLEN,
     ## quality=rowRanges(vcf)$QUAL,
     reads=reads,
     gnomad.freq=info(vcf)$AFMAX,
     method=info(vcf)$METHOD,
     nb.methods=info(vcf)$METHODS)
-  df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique
+  df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique %>%
+    mutate(gene=paste0('[', gene, '](https://www.ncbi.nlm.nih.gov/gene?term=(', gene, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D)'))
   ## PDF version
   cat('\n\n## ', res$type, 'in', paste(unique(df$gene), collapse=' '), '\n\n')
   res %>% kable(booktabs=TRUE) %>% cat

--- a/sv-report.Rmd
+++ b/sv-report.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(echo=FALSE, message=FALSE, warning=FALSE, fig.width=10)
 ## 3: gene list file
 ## 4: gene and LoF intolerance score file
 args = commandArgs(TRUE)
-args = c('na12878-chr11.sniffles.ann.freqGnomADcov10.vcf','na12878-chr11.svim.ann.freqGnomADcov10.vcf','gene_position_info.txt', 'gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz')
+## args = c('na12878-chr11.sniffles.ann.freqGnomADcov10.vcf','na12878-chr11.svim.ann.freqGnomADcov10.vcf','gene_position_info.txt', 'gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz')
 
 ## Load packages
 library(sveval)
@@ -49,10 +49,14 @@ latexLinkGenes <- function(genes){
 latexLinkPli <- function(scores, genes, digits=3){
   paste0('{\\href{https://gnomad.broadinstitute.org/gene/', genes, '}{', round(scores, digits), '}}')
 }
+mdLinkPli <- function(scores, genes, digits=3){
+  paste0('[',round(scores, digits), '](https://gnomad.broadinstitute.org/gene/', genes,')')
+}
 latexLinkPos <- function(chr, pos){
   paste0('{\\href{https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', chr, '%3A', pos-500, '-', pos+500, '}{', chr, ':', pos, '}}')
 }
 col.width='13cm'
+col.width.gene='5cm'
 
 ## Read both VCFs
 vcf.sn = readSVvcf(args[1], vcf.object=TRUE)
@@ -109,6 +113,8 @@ eff.df = lapply(list(vcf.sn, vcf.sv), function(vcf){
 eff.df = do.call(rbind, eff.df)
 ```
 
+# Methods
+
 The structural variants found by [Sniffles](https://github.com/fritzsedlazeck/Sniffles) and [SVIM](https://github.com/eldariont/svim) were annotated by [SnpEff](http://snpeff.sourceforge.net/) and with the frequency of variants in the [gnoma-SV catalog](https://macarthurlab.org/2019/03/20/structural-variants-in-gnomad/).
 
 The variants' "effects" in this report come from SnpEff and follow the format [described in SnpEff documentation](http://snpeff.sourceforge.net/SnpEff_manual.html#eff).
@@ -119,13 +125,13 @@ It represents the probability that the gene is intolerant to loss-of-function va
 A variant affecting a gene with a high pLI score (e.g. >0.9) is more likely to have a biological impact.
 The variants in each section are ordered to show those affecting genes with the highest pLI first.
 
+Note: for testing purposes I added *MUC5B* to the list of genes.
+
 # By variant
 
 ## High impact variants in genes of interest
 
 Genes of interest: `r sort(genes$hgnc_symbol)`.
-
-Note: for testing purposes I added *MUC5B* to the list of genes.
 
 ```{r genesel, results='asis'}
 high.df = eff.df %>% filter(impact=='HIGH', gene %in% genes$hgnc_symbol) %>%
@@ -211,4 +217,107 @@ t = lapply(1:nrow(high.ii), function(ii){
 
 # By gene
 
-*Soon...*
+## Genes of interest
+
+Genes of interest: `r sort(genes$hgnc_symbol)`.
+
+```{r geneselpg, results='asis'}
+high.df = eff.df %>% filter(impact=='HIGH', gene %in% genes$hgnc_symbol) %>%
+  merge(pli.df, all.x=TRUE) %>% arrange(desc(pLI))
+  
+## Write a section for each variant
+t = lapply(unique(high.df$gene), function(gene.name){
+  df = high.df %>% filter(gene==gene.name)
+  vars = tibble()
+  if(any(df$method=='Sniffles')){
+    id.ii = df %>% filter(method=='Sniffles') %>% .$id %>% unique
+    vcf = vcf.sn[id.ii]
+    vars = tibble(
+      id=id.ii,
+      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
+      type=info(vcf)$SVTYPE,
+      size=info(vcf)$SVLEN,
+      ## quality=rowRanges(vcf)$QUAL,
+      reads=info(vcf)$RE,
+      gnomad.freq=info(vcf)$AFMAX,
+      method=info(vcf)$METHOD,
+      nb.methods=info(vcf)$METHODS) %>% rbind(vars)
+  }
+  if(any(df$method=='SVIM')){
+    id.ii = df %>% filter(method=='SVIM') %>% .$id %>% unique
+    vcf = vcf.sv[id.ii]
+    vars = tibble(
+      id=id.ii,
+      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
+      type=info(vcf)$SVTYPE,
+      size=info(vcf)$SVLEN,
+      ## quality=rowRanges(vcf)$QUAL,
+      reads=info(vcf)$SUPPORT,
+      gnomad.freq=info(vcf)$AFMAX,
+      method=info(vcf)$METHOD,
+      nb.methods=info(vcf)$METHODS) %>% rbind(vars)
+  }
+  vars = df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
+                       effect=gsub('_', '\\\\_', effect)) %>%
+    group_by(method, id) %>% summarize(effect=paste(effect, collapse='; ')) %>%
+    merge(vars, .) %>% ungroup %>% select(-id)
+  ## Write Markdown/Latex section
+  cat('\n\n### ', mdLinkGenes(gene.name), '\n\n')
+  cat('\n\n- pLI score: ', mdLinkPli(df$pLI[1], gene.name), '\n\n')
+  eff.coln = which(colnames(vars)=='effect')
+  vars %>% kable(booktabs=TRUE, escape=FALSE) %>%
+    column_spec(eff.coln, width=col.width.gene) %>% cat
+})
+```
+
+## Other protein-coding genes
+
+```{r proteincodingpg, results='asis'}
+high.df = eff.df %>% filter(impact=='HIGH', target.type=='protein_coding',
+                            !(gene %in% genes$hgnc_symbol)) %>%
+  merge(pli.df, all.x=TRUE) %>% arrange(desc(pLI))
+  
+## Write a section for each variant
+t = lapply(unique(high.df$gene), function(gene.name){
+  df = high.df %>% filter(gene==gene.name)
+  vars = tibble()
+  if(any(df$method=='Sniffles')){
+    id.ii = df %>% filter(method=='Sniffles') %>% .$id %>% unique
+    vcf = vcf.sn[id.ii]
+    vars = tibble(
+      id=id.ii,
+      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
+      type=info(vcf)$SVTYPE,
+      size=info(vcf)$SVLEN,
+      ## quality=rowRanges(vcf)$QUAL,
+      reads=info(vcf)$RE,
+      gnomad.freq=info(vcf)$AFMAX,
+      method=info(vcf)$METHOD,
+      nb.methods=info(vcf)$METHODS) %>% rbind(vars)
+  }
+  if(any(df$method=='SVIM')){
+    id.ii = df %>% filter(method=='SVIM') %>% .$id %>% unique
+    vcf = vcf.sv[id.ii]
+    vars = tibble(
+      id=id.ii,
+      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
+      type=info(vcf)$SVTYPE,
+      size=info(vcf)$SVLEN,
+      ## quality=rowRanges(vcf)$QUAL,
+      reads=info(vcf)$SUPPORT,
+      gnomad.freq=info(vcf)$AFMAX,
+      method=info(vcf)$METHOD,
+      nb.methods=info(vcf)$METHODS) %>% rbind(vars)
+  }
+  vars = df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
+                       effect=gsub('_', '\\\\_', effect)) %>%
+    group_by(method, id) %>% summarize(effect=paste(unique(effect), collapse='; ')) %>%
+    merge(vars, .) %>% ungroup %>% select(-id)
+  ## Write Markdown/Latex section
+  cat('\n\n### ', mdLinkGenes(gene.name), '\n\n')
+  cat('\n\n- pLI score: ', mdLinkPli(df$pLI[1], gene.name), '\n\n')
+  eff.coln = which(colnames(vars)=='effect')
+  vars %>% kable(booktabs=TRUE, escape=FALSE) %>%
+    column_spec(eff.coln, width=col.width.gene) %>% cat
+})
+```

--- a/sv-report.Rmd
+++ b/sv-report.Rmd
@@ -27,7 +27,7 @@ knitr::opts_chunk$set(echo=FALSE, message=FALSE, warning=FALSE, fig.width=10)
 ## 4: gene and LoF intolerance score file
 ## 5: simple repeat annotation
 args = commandArgs(TRUE)
-args = c('na12878-chr11.sniffles.ann.freqGnomADcov10.vcf','na12878-chr11.svim.ann.freqGnomADcov10.vcf','gene_position_info.txt', 'gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz', 'simpleRepeat.txt.gz')
+## args = c('na12878-chr11.sniffles.ann.freqGnomADcov10.vcf','na12878-chr11.svim.ann.freqGnomADcov10.vcf','gene_position_info.txt', 'gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz', 'simpleRepeat.txt.gz')
 
 ## Load packages
 library(sveval)

--- a/sv-report.Rmd
+++ b/sv-report.Rmd
@@ -5,9 +5,7 @@ header-includes:
 - \usepackage{booktabs}
 - \usepackage{makecell}
 urlcolor: teal
-output:
-  pdf_document:
-   keep_tex: true 
+output: pdf_document
 ---
 
 ```{r include=FALSE}
@@ -17,6 +15,8 @@ knitr::opts_chunk$set(echo=FALSE, message=FALSE, warning=FALSE, fig.width=10)
 ```{r setup}
 ## Read input arguments
 ## 1: VCF file from Sniffles
+## 2: VCF file from SVIM
+## 3: gene list file
 args = commandArgs(TRUE)
 args = c('na12878-chr11.sniffles.ann.freqGnomADcov10.vcf','na12878-chr11.svim.ann.freqGnomADcov10.vcf','gene_position_info.txt')
 
@@ -35,6 +35,7 @@ parseEff <- function(eff){
   return(tibble(effect=effect, impact=target[[1]], gene=target[[6]],
               target.type=target[[7]]))
 }
+## Format links for genes (NCBI) or genomic position (UCSC Genome Browser)
 mdLinkGenes <- function(genes){
   paste0('[', genes, '](https://www.ncbi.nlm.nih.gov/gene?term=(', genes, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D)')
 }
@@ -76,11 +77,12 @@ info(vcf.sv)$METHOD = 'SVIM'
 ## Read gene list
 genes = read.table(args[3], as.is=TRUE, header=TRUE)
 
-## DEBUG
+## FOR TESTING PURPOSE
 genes$hgnc_symbol[1] = 'MUC5B'
 ```
 
 ```{r highimpact}
+## Select variants with "HIGH" impact and parse the EFF field
 eff.df = lapply(list(vcf.sn, vcf.sv), function(vcf){
   high.ii = which(unlist(lapply(info(vcf)$EFF, function(effs) any(grepl('HIGH', effs)))))
   eff.df = lapply(high.ii, function(ii){
@@ -110,6 +112,7 @@ Note: for testing purposes I added *MUC5B* to the list of genes.
 high.df = eff.df %>% filter(impact=='HIGH', gene %in% genes$hgnc_symbol) %>% arrange(gene)
 high.ii = high.df %>% select(id, method) %>% unique
 
+## Write a section for each variant
 t = lapply(1:nrow(high.ii), function(ii){
   id.ii = high.ii$id[ii]
   if(high.ii$method[ii] == 'Sniffles'){
@@ -119,6 +122,7 @@ t = lapply(1:nrow(high.ii), function(ii){
     vcf = vcf.sv[id.ii]
     reads = info(vcf.sv)$SUPPORT[id.ii]
   }
+  ## Variant info
   res = tibble(
     pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
     type=info(vcf)$SVTYPE,
@@ -128,8 +132,9 @@ t = lapply(1:nrow(high.ii), function(ii){
     gnomad.freq=info(vcf)$AFMAX,
     method=info(vcf)$METHOD,
     nb.methods=info(vcf)$METHODS)
+  ## Effect info
   df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique
-  ## PDF version
+  ## Write Markdown/Latex section
   cat('\n\n## ', res$type, 'in', paste(mdLinkGenes(unique(df$gene)), collapse=' '), '\n\n')
   res %>% kable(booktabs=TRUE, escape=FALSE) %>% cat
   cat('\n\n### Effect(s) \n\n')
@@ -147,6 +152,7 @@ high.df = eff.df %>% filter(impact=='HIGH', target.type=='protein_coding',
                             !(gene %in% genes$hgnc_symbol)) %>% arrange(gene)
 high.ii = high.df %>% select(id, method) %>% unique
 
+## Write a section for each variant
 t = lapply(1:nrow(high.ii), function(ii){
   id.ii = high.ii$id[ii]
   if(high.ii$method[ii] == 'Sniffles'){
@@ -156,6 +162,7 @@ t = lapply(1:nrow(high.ii), function(ii){
     vcf = vcf.sv[id.ii]
     reads = info(vcf.sv)$SUPPORT[id.ii]
   }
+  ## Variant info
   res = tibble(
     pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
     type=info(vcf)$SVTYPE,
@@ -165,8 +172,9 @@ t = lapply(1:nrow(high.ii), function(ii){
     gnomad.freq=info(vcf)$AFMAX,
     method=info(vcf)$METHOD,
     nb.methods=info(vcf)$METHODS)
+  ## Effect info
   df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique
-  ## PDF version
+  ## Write Markdown/Latex section
   cat('\n\n## ', res$type, 'in', paste(mdLinkGenes(unique(df$gene)), collapse=' '), '\n\n')
   res %>% kable(booktabs=TRUE, escape=FALSE) %>% cat
   cat('\n\n### Effect(s) \n\n')

--- a/sv-report.Rmd
+++ b/sv-report.Rmd
@@ -4,7 +4,11 @@ author: UPD-UCSC
 header-includes:
 - \usepackage{booktabs}
 - \usepackage{makecell}
-output: pdf_document
+- \usepackage{makecell}
+urlcolor: teal
+output:
+  pdf_document:
+   keep_tex: true 
 ---
 
 ```{r include=FALSE}
@@ -32,6 +36,16 @@ parseEff <- function(eff){
   return(tibble(effect=effect, impact=target[[1]], gene=target[[6]],
               target.type=target[[7]]))
 }
+mdLinkGenes <- function(genes){
+  paste0('[', genes, '](https://www.ncbi.nlm.nih.gov/gene?term=(', genes, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D)')
+}
+latexLinkGenes <- function(genes){
+  paste0('{\\href{https://www.ncbi.nlm.nih.gov/gene?term=(', genes, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D}{', genes, '}}')
+}
+latexLinkPos <- function(chr, pos){
+  paste0('{\\href{https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', chr, '%3A', pos-500, '-', pos+500, '}{', chr, ':', pos, '}}')
+}
+col.width='13cm'
 
 ## Read both VCFs
 vcf.sn = readSVvcf(args[1], vcf.object=TRUE)
@@ -85,13 +99,13 @@ eff.df = do.call(rbind, eff.df)
 
 The structural variants found by [Sniffles](https://github.com/fritzsedlazeck/Sniffles) and [SVIM](https://github.com/eldariont/svim) were annotated by [SnpEff](http://snpeff.sourceforge.net/) and with the frequency of variants in the [gnoma-SV catalog](https://macarthurlab.org/2019/03/20/structural-variants-in-gnomad/).
 
-The variants "effects" in this report come from SnpEff and follow the format [described in SnpEff documentation](http://snpeff.sourceforge.net/SnpEff_manual.html#eff).
+The variants' "effects" in this report come from SnpEff and follow the format [described in SnpEff documentation](http://snpeff.sourceforge.net/SnpEff_manual.html#eff).
 
 # High impact variants in genes of interest
 
-Genes of interest include: `r sort(genes$hgnc_symbol)`.
+Genes of interest: `r sort(genes$hgnc_symbol)`.
 
-Note: for testing purpose I added *MUC5B* to the list of genes.
+Note: for testing purposes I added *MUC5B* to the list of genes.
 
 ```{r genesel, results='asis'}
 high.df = eff.df %>% filter(impact=='HIGH', gene %in% genes$hgnc_symbol) %>% arrange(gene)
@@ -107,22 +121,23 @@ t = lapply(1:nrow(high.ii), function(ii){
     reads = info(vcf.sv)$SUPPORT[id.ii]
   }
   res = tibble(
+    pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
     type=info(vcf)$SVTYPE,
-    pos=paste0('[', as.character(seqnames(rowRanges(vcf))), ':', start(rowRanges(vcf)), '](https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', as.character(seqnames(rowRanges(vcf))), '%3A', start(rowRanges(vcf))-500, '-', start(rowRanges(vcf))+500, ')')
     size=info(vcf)$SVLEN,
     ## quality=rowRanges(vcf)$QUAL,
     reads=reads,
     gnomad.freq=info(vcf)$AFMAX,
     method=info(vcf)$METHOD,
     nb.methods=info(vcf)$METHODS)
-  df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique %>%
-    mutate(gene=paste0('[', gene, '](https://www.ncbi.nlm.nih.gov/gene?term=(', gene, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D)'))
+  df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique
   ## PDF version
-  cat('\n\n## ', res$type, 'in', paste(unique(df$gene), collapse=' '), '\n\n')
-  res %>% kable(booktabs=TRUE) %>% cat
+  cat('\n\n## ', res$type, 'in', paste(mdLinkGenes(unique(df$gene)), collapse=' '), '\n\n')
+  res %>% kable(booktabs=TRUE, escape=FALSE) %>% cat
   cat('\n\n### Effect(s) \n\n')
-  df %>% mutate(effect=gsub('\\+', ' \\+ ', effect)) %>%
-    kable(booktabs=TRUE) %>% column_spec(2, width='10cm') %>% cat
+  df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
+                effect=gsub('_', '\\\\_', effect),
+                gene=latexLinkGenes(gene)) %>%
+    kable(booktabs=TRUE, escape=FALSE) %>% column_spec(2, width=col.width) %>% cat
 })
 ```
 
@@ -143,22 +158,23 @@ t = lapply(1:nrow(high.ii), function(ii){
     reads = info(vcf.sv)$SUPPORT[id.ii]
   }
   res = tibble(
+    pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf))),
     type=info(vcf)$SVTYPE,
-    pos=paste0('[', as.character(seqnames(rowRanges(vcf))), ':', start(rowRanges(vcf)), '](https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', as.character(seqnames(rowRanges(vcf))), '%3A', start(rowRanges(vcf))-500, '-', start(rowRanges(vcf))+500, ')')
     size=info(vcf)$SVLEN,
     ## quality=rowRanges(vcf)$QUAL,
     reads=reads,
     gnomad.freq=info(vcf)$AFMAX,
     method=info(vcf)$METHOD,
     nb.methods=info(vcf)$METHODS)
-  df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique %>%
-    mutate(gene=paste0('[', gene, '](https://www.ncbi.nlm.nih.gov/gene?term=(', gene, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D)'))
+  df = high.df %>% filter(id==id.ii) %>% select(gene, effect) %>% unique
   ## PDF version
-  cat('\n\n## ', res$type, 'in', paste(unique(df$gene), collapse=' '), '\n\n')
-  res %>% kable(booktabs=TRUE) %>% cat
+  cat('\n\n## ', res$type, 'in', paste(mdLinkGenes(unique(df$gene)), collapse=' '), '\n\n')
+  res %>% kable(booktabs=TRUE, escape=FALSE) %>% cat
   cat('\n\n### Effect(s) \n\n')
-  df %>% mutate(effect=gsub('\\+', ' \\+ ', effect)) %>%
-    kable(booktabs=TRUE) %>% column_spec(2, width='10cm') %>% cat
+  df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
+                effect=gsub('_', '\\\\_', effect),
+                gene=latexLinkGenes(gene)) %>%
+    kable(booktabs=TRUE, escape=FALSE) %>% column_spec(2, width=col.width) %>% cat
 })
 ```
 

--- a/sv-report.Rmd
+++ b/sv-report.Rmd
@@ -9,6 +9,10 @@ output:
   pdf_document:
     toc: true
     toc_depth: 2
+  html_document:
+    toc: true
+    toc_depth: 2
+    toc_float: true
 ---
 
 ```{r include=FALSE}
@@ -21,8 +25,9 @@ knitr::opts_chunk$set(echo=FALSE, message=FALSE, warning=FALSE, fig.width=10)
 ## 2: VCF file from SVIM
 ## 3: gene list file
 ## 4: gene and LoF intolerance score file
+## 5: simple repeat annotation
 args = commandArgs(TRUE)
-## args = c('na12878-chr11.sniffles.ann.freqGnomADcov10.vcf','na12878-chr11.svim.ann.freqGnomADcov10.vcf','gene_position_info.txt', 'gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz')
+args = c('na12878-chr11.sniffles.ann.freqGnomADcov10.vcf','na12878-chr11.svim.ann.freqGnomADcov10.vcf','gene_position_info.txt', 'gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz', 'simpleRepeat.txt.gz')
 
 ## Load packages
 library(sveval)
@@ -30,6 +35,12 @@ library(VariantAnnotation)
 library(dplyr)
 library(knitr)
 library(kableExtra)
+## library(DT)
+
+out.format='html'
+if(is_latex_output()){
+  out.format='pdf'
+}
 
 ## Parse the SnpEff field EFF
 parseEff <- function(eff){
@@ -40,25 +51,129 @@ parseEff <- function(eff){
               target.type=target[[7]]))
 }
 ## Format links for genes (NCBI) or genomic position (UCSC Genome Browser)
-mdLinkGenes <- function(genes){
-  paste0('[', genes, '](https://www.ncbi.nlm.nih.gov/gene?term=(', genes, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D)')
+linkGenes <- function(genes, format='html'){
+  if(format=='html'){
+    return(paste0('[', genes, '](https://www.ncbi.nlm.nih.gov/gene?term=(', genes, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D)'))
+  }
+  if(format=='pdf'){
+    return(paste0('{\\href{https://www.ncbi.nlm.nih.gov/gene?term=(', genes, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D}{', genes, '}}'))
+  }
 }
-latexLinkGenes <- function(genes){
-  paste0('{\\href{https://www.ncbi.nlm.nih.gov/gene?term=(', genes, '%5BGene%20Name%5D)%20AND%20Human%5BOrganism%5D}{', genes, '}}')
+linkPli <- function(scores, genes, digits=3, format='html'){
+  if(format=='pdf'){
+    return(paste0('{\\href{https://gnomad.broadinstitute.org/gene/', genes, '}{', round(scores, digits), '}}'))
+  }
+  if(format=='html'){
+    return(paste0('[',round(scores, digits), '](https://gnomad.broadinstitute.org/gene/', genes,')'))
+  }
 }
-latexLinkPli <- function(scores, genes, digits=3){
-  paste0('{\\href{https://gnomad.broadinstitute.org/gene/', genes, '}{', round(scores, digits), '}}')
-}
-mdLinkPli <- function(scores, genes, digits=3){
-  paste0('[',round(scores, digits), '](https://gnomad.broadinstitute.org/gene/', genes,')')
-}
-latexLinkPos <- function(chr, pos, type, size, flanks=500){
+linkPos <- function(chr, pos, type, size, flanks=500, format='html'){
   size = ifelse(type %in% c('DEL','DUP','INV'), abs(size), 1)
-  paste0('{\\href{https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', chr, '%3A', pos-flanks, '-', pos+size+flanks,
-         '&highlight=hg38.', chr, '%3A', pos, '-', pos+size, '%23AA0000}{', chr, ':', pos, '}}')
+  if(format=='pdf'){
+    return(paste0('{\\href{https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=', chr, '%3A',
+                  pos-flanks, '-', pos+size+flanks, '&highlight=hg38.', chr, '%3A', pos, '-',
+                  pos+size, '%23AA0000}{', chr, ':', pos, '}}'))
+  }
+  if(format=='html'){
+    return(paste0('[', chr, ':', pos, '](https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=',
+                  chr, '%3A', pos-flanks, '-', pos+size+flanks, '&highlight=hg38.', chr, '%3A', pos,
+                  '-', pos+size, '%23AA0000)'))
+  }
 }
+
 col.width='13cm'
 col.width.gene='5cm'
+writeByGeneSection <- function(gene.name, high.df, vcf.sn, vcf.sv, format='pdf'){
+  df = high.df %>% filter(gene==gene.name)
+  vars = tibble()
+  if(any(df$method=='Sniffles')){
+    id.ii = df %>% filter(method=='Sniffles') %>% .$id %>% unique
+    vcf = vcf.sn[id.ii]
+    vars = tibble(
+      id=id.ii,
+      pos=linkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN, format=format),
+      type=info(vcf)$SVTYPE,
+      size=info(vcf)$SVLEN,
+      ## quality=rowRanges(vcf)$QUAL,
+      reads=info(vcf)$RE,
+      freq=info(vcf)$AFMAX,
+      simp.rep=info(vcf)$ol.simple.repeat,
+      method=info(vcf)$METHOD,
+      nmeths=info(vcf)$METHODS) %>% rbind(vars)
+  }
+  if(any(df$method=='SVIM')){
+    id.ii = df %>% filter(method=='SVIM') %>% .$id %>% unique
+    vcf = vcf.sv[id.ii]
+    vars = tibble(
+      id=id.ii,
+      pos=linkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN, format=format),
+      type=info(vcf)$SVTYPE,
+      size=info(vcf)$SVLEN,
+      ## quality=rowRanges(vcf)$QUAL,
+      reads=info(vcf)$SUPPORT,
+      freq=info(vcf)$AFMAX,
+      simp.rep=info(vcf)$ol.simple.repeat,
+      method=info(vcf)$METHOD,
+      nmeths=info(vcf)$METHODS) %>% rbind(vars)
+  }
+  vars = df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
+                       effect=gsub('_', '\\\\_', effect)) %>%
+    group_by(method, id) %>% summarize(effect=paste(unique(effect), collapse='; ')) %>%
+    merge(vars, .) %>% ungroup %>% select(-id)
+  cat('\n\n### ', linkGenes(gene.name), '\n\n')
+  cat('\n\n- pLI score: ', linkPli(df$pLI[1], gene.name), '\n\n')
+  if(format == 'pdf'){
+    eff.coln = which(colnames(vars)=='effect')
+    vars %>% kable(booktabs=TRUE, escape=FALSE) %>%
+      column_spec(eff.coln, width=col.width.gene) %>% cat
+  }
+  if(format == 'html'){
+    ## datatable(vars)
+    vars %>% kable(format='html') %>% kable_styling() %>% cat
+  }
+}
+writeByVariantSection <- function(ii, high.ii, high.df, vcf.sn, vcf.sv, format=out.format){
+  id.ii = high.ii$id[ii]
+  if(high.ii$method[ii] == 'Sniffles'){
+    vcf = vcf.sn[id.ii]
+    reads = info(vcf.sn)$RE[id.ii]
+  } else {
+    vcf = vcf.sv[id.ii]
+    reads = info(vcf.sv)$SUPPORT[id.ii]
+  }
+  ## Variant info
+  res = tibble(
+    pos=linkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN, format=format),
+    type=info(vcf)$SVTYPE,
+    size=info(vcf)$SVLEN,
+    ## quality=rowRanges(vcf)$QUAL,
+    reads=reads,
+    freq=info(vcf)$AFMAX,
+    simp.rep=info(vcf)$ol.simple.repeat,
+    method=info(vcf)$METHOD,
+    nmeths=info(vcf)$METHODS)
+  ## Effect info
+  df = high.df %>% filter(id==id.ii) %>% select(gene, effect, pLI) %>% unique
+  ## Write Markdown/Latex section
+  cat('\n\n### ', res$type, 'in', paste(linkGenes(unique(df$gene)), collapse=' '), '\n\n')
+  if(format=='pdf'){
+    res %>% kable(booktabs=TRUE, escape=FALSE) %>% cat
+  }
+  if(format=='html'){
+    res %>% kable(format='html') %>% kable_styling() %>% cat
+  }
+  cat('\n\n#### Effect(s) \n\n')
+  df = df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
+                  effect=gsub('_', '\\\\_', effect),
+                  pLI=linkPli(pLI, gene, format=format),
+                  gene=linkGenes(gene, format=format))
+  if(format=='pdf'){
+    kable(df, booktabs=TRUE, escape=FALSE) %>% column_spec(2, width=col.width) %>% cat
+  }
+  if(format=='html'){
+    kable(df, format='html') %>% kable_styling() %>% cat
+  }
+}
 
 ## Read both VCFs
 vcf.sn = readSVvcf(args[1], vcf.object=TRUE)
@@ -93,6 +208,14 @@ genes = read.table(args[3], as.is=TRUE, header=TRUE)
 ## Read pli score
 pli.df = read.table(args[4], as.is=TRUE, header=TRUE, sep='\t')
 pli.df = pli.df %>% select(gene, pLI)
+
+## Simple repeats
+sr = read.table(args[5])
+sr = sr[,c(2,3,4,6,7,17)]
+colnames(sr) = c('chrom', 'start', 'end', 'period', 'copyNum', 'sequence')
+sr = makeGRangesFromDataFrame(sr, keep.extra.columns=TRUE)
+info(vcf.sn)$ol.simple.repeat = overlapsAny(vcf.sn, sr)
+info(vcf.sv)$ol.simple.repeat = overlapsAny(vcf.sv, sr)
 
 ## FOR TESTING PURPOSE
 genes$hgnc_symbol[1] = 'MUC5B'
@@ -129,7 +252,37 @@ The variants in each section are ordered to show those affecting genes with the 
 
 Note: for testing purposes I added *MUC5B* to the list of genes.
 
-# By variant
+# By gene {.tabset}
+
+## Genes of interest
+
+Genes of interest: `r sort(genes$hgnc_symbol)`.
+
+```{r geneselpg, results='asis'}
+high.df = eff.df %>% filter(impact=='HIGH', gene %in% genes$hgnc_symbol) %>%
+  merge(pli.df, all.x=TRUE) %>% arrange(desc(pLI))
+  
+## Write a section for each variant
+t = lapply(unique(high.df$gene), function(gene.name){
+  writeByGeneSection(gene.name, high.df, vcf.sn, vcf.sv, format=out.format)  
+})
+
+```
+
+## Other protein-coding genes
+
+```{r proteincodingpg, results='asis'}
+high.df = eff.df %>% filter(impact=='HIGH', target.type=='protein_coding',
+                            !(gene %in% genes$hgnc_symbol)) %>%
+  merge(pli.df, all.x=TRUE) %>% arrange(desc(pLI))
+  
+## Write a section for each variant
+t = lapply(unique(high.df$gene), function(gene.name){
+  writeByGeneSection(gene.name, high.df, vcf.sn, vcf.sv, format=out.format)  
+})
+```
+
+# By variant {.tabset}
 
 ## High impact variants in genes of interest
 
@@ -143,35 +296,7 @@ high.ii = high.df %>% select(id, method) %>% unique
 
 ## Write a section for each variant
 t = lapply(1:nrow(high.ii), function(ii){
-  id.ii = high.ii$id[ii]
-  if(high.ii$method[ii] == 'Sniffles'){
-    vcf = vcf.sn[id.ii]
-    reads = info(vcf.sn)$RE[id.ii]
-  } else {
-    vcf = vcf.sv[id.ii]
-    reads = info(vcf.sv)$SUPPORT[id.ii]
-  }
-  ## Variant info
-  res = tibble(
-    pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
-    type=info(vcf)$SVTYPE,
-    size=info(vcf)$SVLEN,
-    ## quality=rowRanges(vcf)$QUAL,
-    reads=reads,
-    gnomad.freq=info(vcf)$AFMAX,
-    method=info(vcf)$METHOD,
-    nb.methods=info(vcf)$METHODS)
-  ## Effect info
-  df = high.df %>% filter(id==id.ii) %>% select(gene, effect, pLI) %>% unique
-  ## Write Markdown/Latex section
-  cat('\n\n### ', res$type, 'in', paste(mdLinkGenes(unique(df$gene)), collapse=' '), '\n\n')
-  res %>% kable(booktabs=TRUE, escape=FALSE) %>% cat
-  cat('\n\n#### Effect(s) \n\n')
-  df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
-                effect=gsub('_', '\\\\_', effect),
-                pLI=latexLinkPli(pLI, gene),
-                gene=latexLinkGenes(gene)) %>%
-    kable(booktabs=TRUE, escape=FALSE) %>% column_spec(2, width=col.width) %>% cat
+  writeByVariantSection(ii, high.ii, high.df, vcf.sn, vcf.sv, format=out.format)
 })
 ```
 
@@ -185,141 +310,7 @@ high.ii = high.df %>% select(id, method) %>% unique
 
 ## Write a section for each variant
 t = lapply(1:nrow(high.ii), function(ii){
-  id.ii = high.ii$id[ii]
-  if(high.ii$method[ii] == 'Sniffles'){
-    vcf = vcf.sn[id.ii]
-    reads = info(vcf.sn)$RE[id.ii]
-  } else {
-    vcf = vcf.sv[id.ii]
-    reads = info(vcf.sv)$SUPPORT[id.ii]
-  }
-  ## Variant info
-  res = tibble(
-    pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
-    type=info(vcf)$SVTYPE,
-    size=info(vcf)$SVLEN,
-    ## quality=rowRanges(vcf)$QUAL,
-    reads=reads,
-    gnomad.freq=info(vcf)$AFMAX,
-    method=info(vcf)$METHOD,
-    nb.methods=info(vcf)$METHODS)
-  ## Effect info
-  df = high.df %>% filter(id==id.ii) %>% select(gene, effect, pLI) %>% unique
-  ## Write Markdown/Latex section
-  cat('\n\n### ', res$type, 'in', paste(mdLinkGenes(unique(df$gene)), collapse=' '), '\n\n')
-  res %>% kable(booktabs=TRUE, escape=FALSE) %>% cat
-  cat('\n\n#### Effect(s) \n\n')
-  df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
-                effect=gsub('_', '\\\\_', effect),
-                pLI=latexLinkPli(pLI, gene),
-                gene=latexLinkGenes(gene)) %>%
-    kable(booktabs=TRUE, escape=FALSE) %>% column_spec(2, width=col.width) %>% cat
+  writeByVariantSection(ii, high.ii, high.df, vcf.sn, vcf.sv, format=out.format)
 })
 ```
 
-# By gene
-
-## Genes of interest
-
-Genes of interest: `r sort(genes$hgnc_symbol)`.
-
-```{r geneselpg, results='asis'}
-high.df = eff.df %>% filter(impact=='HIGH', gene %in% genes$hgnc_symbol) %>%
-  merge(pli.df, all.x=TRUE) %>% arrange(desc(pLI))
-  
-## Write a section for each variant
-t = lapply(unique(high.df$gene), function(gene.name){
-  df = high.df %>% filter(gene==gene.name)
-  vars = tibble()
-  if(any(df$method=='Sniffles')){
-    id.ii = df %>% filter(method=='Sniffles') %>% .$id %>% unique
-    vcf = vcf.sn[id.ii]
-    vars = tibble(
-      id=id.ii,
-      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
-      type=info(vcf)$SVTYPE,
-      size=info(vcf)$SVLEN,
-      ## quality=rowRanges(vcf)$QUAL,
-      reads=info(vcf)$RE,
-      gnomad.freq=info(vcf)$AFMAX,
-      method=info(vcf)$METHOD,
-      nb.methods=info(vcf)$METHODS) %>% rbind(vars)
-  }
-  if(any(df$method=='SVIM')){
-    id.ii = df %>% filter(method=='SVIM') %>% .$id %>% unique
-    vcf = vcf.sv[id.ii]
-    vars = tibble(
-      id=id.ii,
-      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
-      type=info(vcf)$SVTYPE,
-      size=info(vcf)$SVLEN,
-      ## quality=rowRanges(vcf)$QUAL,
-      reads=info(vcf)$SUPPORT,
-      gnomad.freq=info(vcf)$AFMAX,
-      method=info(vcf)$METHOD,
-      nb.methods=info(vcf)$METHODS) %>% rbind(vars)
-  }
-  vars = df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
-                       effect=gsub('_', '\\\\_', effect)) %>%
-    group_by(method, id) %>% summarize(effect=paste(effect, collapse='; ')) %>%
-    merge(vars, .) %>% ungroup %>% select(-id)
-  ## Write Markdown/Latex section
-  cat('\n\n### ', mdLinkGenes(gene.name), '\n\n')
-  cat('\n\n- pLI score: ', mdLinkPli(df$pLI[1], gene.name), '\n\n')
-  eff.coln = which(colnames(vars)=='effect')
-  vars %>% kable(booktabs=TRUE, escape=FALSE) %>%
-    column_spec(eff.coln, width=col.width.gene) %>% cat
-})
-```
-
-## Other protein-coding genes
-
-```{r proteincodingpg, results='asis'}
-high.df = eff.df %>% filter(impact=='HIGH', target.type=='protein_coding',
-                            !(gene %in% genes$hgnc_symbol)) %>%
-  merge(pli.df, all.x=TRUE) %>% arrange(desc(pLI))
-  
-## Write a section for each variant
-t = lapply(unique(high.df$gene), function(gene.name){
-  df = high.df %>% filter(gene==gene.name)
-  vars = tibble()
-  if(any(df$method=='Sniffles')){
-    id.ii = df %>% filter(method=='Sniffles') %>% .$id %>% unique
-    vcf = vcf.sn[id.ii]
-    vars = tibble(
-      id=id.ii,
-      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
-      type=info(vcf)$SVTYPE,
-      size=info(vcf)$SVLEN,
-      ## quality=rowRanges(vcf)$QUAL,
-      reads=info(vcf)$RE,
-      gnomad.freq=info(vcf)$AFMAX,
-      method=info(vcf)$METHOD,
-      nb.methods=info(vcf)$METHODS) %>% rbind(vars)
-  }
-  if(any(df$method=='SVIM')){
-    id.ii = df %>% filter(method=='SVIM') %>% .$id %>% unique
-    vcf = vcf.sv[id.ii]
-    vars = tibble(
-      id=id.ii,
-      pos=latexLinkPos(as.character(seqnames(rowRanges(vcf))), start(rowRanges(vcf)), info(vcf)$SVTYPE, info(vcf)$SVLEN),
-      type=info(vcf)$SVTYPE,
-      size=info(vcf)$SVLEN,
-      ## quality=rowRanges(vcf)$QUAL,
-      reads=info(vcf)$SUPPORT,
-      gnomad.freq=info(vcf)$AFMAX,
-      method=info(vcf)$METHOD,
-      nb.methods=info(vcf)$METHODS) %>% rbind(vars)
-  }
-  vars = df %>% mutate(effect=gsub('\\+', ' \\+ ', effect),
-                       effect=gsub('_', '\\\\_', effect)) %>%
-    group_by(method, id) %>% summarize(effect=paste(unique(effect), collapse='; ')) %>%
-    merge(vars, .) %>% ungroup %>% select(-id)
-  ## Write Markdown/Latex section
-  cat('\n\n### ', mdLinkGenes(gene.name), '\n\n')
-  cat('\n\n- pLI score: ', mdLinkPli(df$pLI[1], gene.name), '\n\n')
-  eff.coln = which(colnames(vars)=='effect')
-  vars %>% kable(booktabs=TRUE, escape=FALSE) %>%
-    column_spec(eff.coln, width=col.width.gene) %>% cat
-})
-```


### PR DESCRIPTION
I added a command to annotate SVs with their frequency in gnomAD-SV and a R-Markdown report that automatically extract high-impact variants.

- Gene-centric sections and variant-centric sections. 
- Genes from the list of interest have their own section. 
- Genes are ordered by decreasing probability of loss-of-function intolerance (from gnomAD).
- SVs are flagged if overlapping simple repeats (repeat expansion?)
- SV calls from the two methods, Sniffles and SVIM, are compared to highlight variants found in both.

The new commands use VCF files that have been annotated with SnpEff although it is not currently part of the Makefile. @rcurrie do you have the SnpEff code somewhere? 